### PR TITLE
style: change site background color and font

### DIFF
--- a/docs/chateau-chanders/gaining-entry.md
+++ b/docs/chateau-chanders/gaining-entry.md
@@ -7,6 +7,7 @@ sidebar_position: 1
 
 ## Front Door
 - If you have a housekey, you are very Special.
+- If you don't already have a housekey, there'll be a lockbox hanging on the front doorknob with a super secret combination that only you and I know.
 
 ## Garage Door
 - You should have the code, call me if you don't.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,10 +1,5 @@
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
+@import url('https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:ital,wght@0,400..900;1,400..900&display=swap');
 
-/* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #5ACDE8;
   --ifm-color-primary-dark: #5ACDE8;
@@ -15,6 +10,10 @@
   --ifm-color-primary-lightest: #5ACDE8;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  font-family: "Schibsted Grotesk", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -27,4 +26,9 @@
   --ifm-color-primary-lighter: #5ACDE8;
   --ifm-color-primary-lightest: #5ACDE8;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+html[data-theme='dark'] {
+  --ifm-background-color: #000000;
+  --ifm-background-surface-color: #000000;
 }


### PR DESCRIPTION
- Updated css styling background color to a deeper black in dark mode (no change to light mode)
- Changed default font to [Google font Schibsted Grotesk](https://fonts.google.com/specimen/Schibsted+Grotesk)
- Added to Chateau Chanders page